### PR TITLE
Check for window._$jscoverage

### DIFF
--- a/lib/lcov.js
+++ b/lib/lcov.js
@@ -16,7 +16,9 @@ exports = module.exports = LCov;
 
 function LCov(runner) {
   runner.on('end', function(){
-    var cov = global._$jscoverage || {};
+    // In a browser context, coverage will be in window.$jscoverage.
+    var g = typeof(global) != 'undefined' ? global : window;
+    var cov = g._$jscoverage || {};
 
     for (var filename in cov) {
       var data = cov[filename];


### PR DESCRIPTION
This allows `mocha-lcov-reporter` to be used in a browser context, e.g. under [`mocha-phantomjs`][1].

[1]: https://github.com/metaskills/mocha-phantomjs